### PR TITLE
Encourage addition of new committers

### DIFF
--- a/docs/process.html
+++ b/docs/process.html
@@ -57,6 +57,7 @@
       <ul>
         <li>Conduct a discussion on the public developer list whether to dissolve the PMC. Do not conduct it on the private PMC list.</li>
         <li>Consider an appeal to the user list for interested users to provide their interest in helping out more.</li>
+	<li>Consider whether any contributors might be candidates for promotion to committers or PMC members.</li>li>
         <li>Conduct a PMC vote on the public dev list. </li>
         <li>If the PMC votes to dissolve the PMC and move to the Attic, inform the board of the successful vote on board@ mailing list (linking or forwarding the 'successful' vote) and add a <a href="resolution.html">resolution</a> to dissolve the PMC to the next board meeting agenda. </li>
         <li>If the PMC can't get enough people to vote to dissolve the PMC (and there are not three -1 votes), then that is grounds for moving to the Attic. They should inform the board as above, noting that the vote failed to get enough votes. </li>


### PR DESCRIPTION
Perhaps this doesn't need to be said, but a number of projects, recently, have managed to continue by adding committers and thus giving them more ownership.